### PR TITLE
Remove unused functions

### DIFF
--- a/dhara/map.c
+++ b/dhara/map.c
@@ -39,11 +39,6 @@ static inline dhara_sector_t ck_get_count(const uint8_t *cookie)
 	return dhara_r32(cookie);
 }
 
-static inline void meta_clear(uint8_t *meta)
-{
-	memset(meta, 0xff, DHARA_META_SIZE);
-}
-
 static inline dhara_sector_t meta_get_id(const uint8_t *meta)
 {
 	return dhara_r32(meta);

--- a/tools/gftool.c
+++ b/tools/gftool.c
@@ -176,14 +176,6 @@ static inline gf_elem_t mod_s(gf_elem_t x)
  * Polynomial search
  */
 
-static inline void bit_clear(uint8_t *map, poly_t i)
-{
-	const uint8_t mask = 1 << (i & 7);
-	const size_t pos = i >> 3;
-
-	map[pos] &= ~mask;
-}
-
 static inline void bit_set(uint8_t *map, poly_t i)
 {
 	const uint8_t mask = 1 << (i & 7);


### PR DESCRIPTION
Functions `meta_clear()` and `bit_clear()` are unused and lead to compiler errors when compiling with clang using the flags `-Wunused-function` and `-Werror`.

```
clang  -O1 -Wall -ggdb -I. -o dhara/map.o -c dhara/map.c
dhara/map.c:42:20: warning: unused function 'meta_clear' [-Wunused-function]
   42 | static inline void meta_clear(uint8_t *meta)
      | 
```

```
clang  -O1 -Wall -ggdb -I. -o tools/gftool.o -c tools/gftool.c
tools/gftool.c:179:20: warning: unused function 'bit_clear' [-Wunused-function]
  179 | static inline void bit_clear(uint8_t *map, poly_t i)
```